### PR TITLE
Fixed typos in game source links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,17 +216,17 @@ The game also has a lot of forks that add their own features, difficulty scaling
 
 - **CroftEngine** - An open-source Tomb Raider 1 engine remake. [[source]](https://github.com/stohrendorf/CroftEngine)
 
-- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[soruce]](https://github.com/WolfireGames/lugaru)
+- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[source]](https://github.com/WolfireGames/lugaru)
 
 - **[OpenLara](http://xproger.info/projects/OpenLara)** - Classic Tomb Raider open-source engine [[source]](https://github.com/XProger/OpenLara)
 
 - **[OpenRW](https://openrw.org)** - A Grand Theft Auto III re-implementation. [[source]](https://github.com/rwengine/openrw)
 
-- **[Overgrowth](https://overgrowth.wolfire.com)** - The sequel to Lugaru. [[soruce]](https://github.com/WolfireGames/overgrowth)
+- **[Overgrowth](https://overgrowth.wolfire.com)** - The sequel to Lugaru. [[source]](https://github.com/WolfireGames/overgrowth)
 
 - **RE3** - The fully reversed source code for GTA III and GTA VC. [[source]](https://github.com/halpz/re3)
 
-- **[Tomb Engine](https://tombengine.com)** - An open-source engine for custom Tomb Raider adventures. [[dource]](https://github.com/TombEngine/TombEngine)
+- **[Tomb Engine](https://tombengine.com)** - An open-source engine for custom Tomb Raider adventures. [[source]](https://github.com/TombEngine/TombEngine)
 
 ## Tower Defense games
 


### PR DESCRIPTION
Corrected [soruce] and [dource] to [source] for Lugaru, Overgrowth, and Tomb Engine.