### PR TITLE
Add Tremulous and Unvanquished

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ This is a list of different open-source video games and commercial video games o
 
 - **[The Dark Mod](https://www.thedarkmod.com/main)** - First-person stealth video game. [[source]](https://svn.thedarkmod.com/publicsvn/darkmod_src/trunk)
 
+- **[Tremulous](https://tremulous.net)** - First-person aliens vs. humans real-time strategy game. [[source]](https://github.com/GrangerHub/tremulous)
+
+- **[Unvanquished](https://unvanquished.net)** - First-person aliens vs. humans real-time strategy game, continuation of Tremulous. [[source]](https://github.com/Unvanquished/Unvanquished) **Engine: [Dæmon](https://wiki.unvanquished.net/wiki/Daemon)** [[source]](https://github.com/DaemonEngine/Daemon)
+
 - **[Xonotic](https://xonotic.org)** - An addictive arena-style first person shooter with crisp movement and a wide array of weapons. [[source]](https://gitlab.com/xonotic/xonotic)
 
 ### *[Aliens Versus Predator](https://en.wikipedia.org/wiki/Aliens_Versus_Predator_(1999_video_game)) game source ports*


### PR DESCRIPTION
Tremulous and Unvanquished are both FPS and RTS, but we better list it as FPS because RTS players would expect a top-down view.

The original source of Tremulous is there:

- https://github.com/darklegion/tremulous

But it's probably better to link the actually maintained repository:

- https://github.com/GrangerHub/tremulous

So I linked the GrangerHub source instead, which is itself recommended on the Tremulous web page:

- https://tremulous.net

Unvanquished started 14 years ago as a continuation of Tremulous, with the joint forces from some developers of the never-released Tremulous 1.2, many well-known contributors of the Tremulous community and some fresh blood. In parallel some people did some maintenance to Tremulous like the GrangerHub project, while Unvanquished does big efforts to push the game, the artistic data and the engine forward.

Unvanquished web site:

- https://unvanquished.net/

Unvanquished source:

- https://github.com/Unvanquished/Unvanquished
- http://github.com/UnvanquishedAssets/UnvanquishedAssets

Unvanquished uses the Dæmon engine, which is open-source too:

- https://wiki.unvanquished.net/wiki/Daemon
- https://github.com/DaemonEngine/Daemon

---

For more information on them, here are the Wikipedia pages for Tremulous and Unvanquished:

- https://en.wikipedia.org/wiki/Tremulous
- https://en.wikipedia.org/wiki/Unvanquished_(video_game)