### PR TITLE
docs(readme): add primary language tag to game entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,37 +43,37 @@ This is a list of different open-source video games and commercial video games o
 
 ## Business and Tycoon games
 
-- **[CorsixTH](https://corsixth.com)** - Open source clone of [Theme Hospital](https://en.wikipedia.org/wiki/Theme_Hospital). [[source]](https://github.com/CorsixTH/CorsixTH)
+- **[CorsixTH](https://corsixth.com)** - Open source clone of [Theme Hospital](https://en.wikipedia.org/wiki/Theme_Hospital). [[source]](https://github.com/CorsixTH/CorsixTH) **Languages: C++**
 
-- **[Hurry Curry!](https://hurrycurry.org)** - Cooperative fast-paced multiplayer cooking game. [[source]](https://codeberg.org/hurrycurry/hurrycurry)
+- **[Hurry Curry!](https://hurrycurry.org)** - Cooperative fast-paced multiplayer cooking game. [[source]](https://codeberg.org/hurrycurry/hurrycurry) **Languages: GDScript**
 
-- **[OpenLoco](https://openloco.io)** - An open source re-implementation of [Chris Sawyer](https://en.wikipedia.org/wiki/Chris_Sawyer)'s [Locomotion](https://en.wikipedia.org/wiki/Chris_Sawyer%27s_Locomotion). [[source]](https://github.com/OpenLoco/OpenLoco)
+- **[OpenLoco](https://openloco.io)** - An open source re-implementation of [Chris Sawyer](https://en.wikipedia.org/wiki/Chris_Sawyer)'s [Locomotion](https://en.wikipedia.org/wiki/Chris_Sawyer%27s_Locomotion). [[source]](https://github.com/OpenLoco/OpenLoco) **Languages: C++**
 
-- **[OpenRCT2](https://openrct2.org)** - An open-source re-implementation of *[RollerCoaster Tycoon 2](https://en.wikipedia.org/wiki/RollerCoaster_Tycoon_2)*. [[source]](https://github.com/OpenRCT2/OpenRCT2)
+- **[OpenRCT2](https://openrct2.org)** - An open-source re-implementation of *[RollerCoaster Tycoon 2](https://en.wikipedia.org/wiki/RollerCoaster_Tycoon_2)*. [[source]](https://github.com/OpenRCT2/OpenRCT2) **Languages: C++**
 
-- **[OpenTTD](https://www.openttd.org)** - An open source simulation game based upon *[Transport Tycoon Deluxe](https://en.wikipedia.org/wiki/Transport_Tycoon)*. [[source]](https://github.com/OpenTTD/OpenTTD)
+- **[OpenTTD](https://www.openttd.org)** - An open source simulation game based upon *[Transport Tycoon Deluxe](https://en.wikipedia.org/wiki/Transport_Tycoon)*. [[source]](https://github.com/OpenTTD/OpenTTD) **Languages: C++**
 
 ## City-Building games
 
-- **[Akhenaten](https://dalerank.itch.io/akhenaten)** - A strategic city-building game, based on assets and gameplay mechanics from *[Pharaoh + Cleopatra](https://en.wikipedia.org/wiki/Pharaoh_(video_game))* title, where players take on the role of a ruler and mayor of ancient Egyptian civilization. [[source]](https://github.com/dalerank/Akhenaten)
+- **[Akhenaten](https://dalerank.itch.io/akhenaten)** - A strategic city-building game, based on assets and gameplay mechanics from *[Pharaoh + Cleopatra](https://en.wikipedia.org/wiki/Pharaoh_(video_game))* title, where players take on the role of a ruler and mayor of ancient Egyptian civilization. [[source]](https://github.com/dalerank/Akhenaten) **Languages: C++**
 
-- **[Citybound](https://aeplay.org/citybound)** - A city building game that uses microscopic models to vividly simulate the organism of a city arising from the interactions of millions of individuals. [[source]](https://github.com/citybound/citybound)
+- **[Citybound](https://aeplay.org/citybound)** - A city building game that uses microscopic models to vividly simulate the organism of a city arising from the interactions of millions of individuals. [[source]](https://github.com/citybound/citybound) **Languages: Rust**
 
-- **[Cytopia](https://cytopia.itch.io/cytopia)** - A free, open source retro pixel-art city building game. [[source]](https://github.com/CytopiaTeam/Cytopia)
+- **[Cytopia](https://cytopia.itch.io/cytopia)** - A free, open source retro pixel-art city building game. [[source]](https://github.com/CytopiaTeam/Cytopia) **Languages: C++**
 
-- **Egregoria** - Egregoria is an indie city builder, mostly inspired by *[Cities: Skylines](https://en.wikipedia.org/wiki/Cities:_Skylines)*. [[source]](https://github.com/Uriopass/Egregoria)
+- **Egregoria** - Egregoria is an indie city builder, mostly inspired by *[Cities: Skylines](https://en.wikipedia.org/wiki/Cities:_Skylines)*. [[source]](https://github.com/Uriopass/Egregoria) **Languages: Rust**
 
-- **[IsoCity](https://iso-city.com)** - Isometric city-building simulation game built with NextJS, TypeScript and TailwindCSS. [[source]](https://github.com/amilich/isometric-city)
+- **[IsoCity](https://iso-city.com)** - Isometric city-building simulation game built with NextJS, TypeScript and TailwindCSS. [[source]](https://github.com/amilich/isometric-city) **Languages: TypeScript**
+ 
+- **Julius** - An open source re-implementation of *[Caesar III](https://en.wikipedia.org/wiki/Caesar_III)*. [[source]](https://github.com/bvschaik/julius) **Languages: C**
 
-- **Julius** - An open source re-implementation of *[Caesar III](https://en.wikipedia.org/wiki/Caesar_III)*. [[source]](https://github.com/bvschaik/julius)
-
-- **[micropolisJS](http://www.graememcc.co.uk/micropolisJS)** - A handmade Javascript port of the open-source city simulator *[Micropolis](https://mvolution.itch.io/micropolis)*. [[source]](https://github.com/graememcc/micropolisJS)
+- **[micropolisJS](http://www.graememcc.co.uk/micropolisJS)** - A handmade Javascript port of the open-source city simulator *[Micropolis](https://mvolution.itch.io/micropolis)*. [[source]](https://github.com/graememcc/micropolisJS) **Languages: JavaScript**
 
 - **[Unknown Horizons](https://unknown-horizons.org)** - A 2D realtime strategy simulation with an emphasis on economy and city building.
 
-  - **Original:** [[source]](https://github.com/unknown-horizons/unknown-horizons) **Engine: [FIFE](https://www.fifengine.net/)** [[source]](https://github.com/fifengine/fifengine)
+  - **Original:** [[source]](https://github.com/unknown-horizons/unknown-horizons) **Engine: [FIFE](https://www.fifengine.net/)** [[source]](https://github.com/fifengine/fifengine) **Languages: Python**
 
-  - **Godot port:** [[source]](https://github.com/unknown-horizons/godot-port) **Engine: [Godot](https://godotengine.org)** [[source]](https://github.com/godotengine/godot)
+  - **Godot port:** [[source]](https://github.com/unknown-horizons/godot-port) **Engine: [Godot](https://godotengine.org)** [[source]](https://github.com/godotengine/godot) **Languages: GDScript**
 
 ## First-Person games
 

--- a/README.md
+++ b/README.md
@@ -77,83 +77,83 @@ This is a list of different open-source video games and commercial video games o
 
 ## First-Person games
 
-- **[.kkrieger](https://en.wikipedia.org/wiki/.kkrieger)** - A first-person shooter video game created by German demogroup .theprodukkt (a former subdivision of [Farbrausch](https://en.wikipedia.org/wiki/Farbrausch)), which won first place in the 96k game competition at [Breakpoint](https://en.wikipedia.org/wiki/Breakpoint_(demoparty)) in April 2004. [[source]](https://github.com/farbrausch/fr_public/tree/master/werkkzeug3_kkrieger)
+- **[.kkrieger](https://en.wikipedia.org/wiki/.kkrieger)** - A first-person shooter video game created by German demogroup .theprodukkt (a former subdivision of [Farbrausch](https://en.wikipedia.org/wiki/Farbrausch)), which won first place in the 96k game competition at [Breakpoint](https://en.wikipedia.org/wiki/Breakpoint_(demoparty)) in April 2004. [[source]](https://github.com/farbrausch/fr_public/tree/master/werkkzeug3_kkrieger) **Language: C++**
 
-- **[Anarch](https://drummyfish.gitlab.io/anarch)** - This isn't a 90s style retro shooter, this is a 90s shooter. [[source]](https://gitlab.com/drummyfish/anarch)
+- **[Anarch](https://drummyfish.gitlab.io/anarch)** - This isn't a 90s style retro shooter, this is a 90s shooter. [[source]](https://gitlab.com/drummyfish/anarch) **Language: C**
 
-- **[AssaultCube](https://assault.cubers.net)** - A FREE, multiplayer, first-person shooter game. [[source]](https://github.com/assaultcube/AC) **Engine: [CUBE](http://cubeengine.com)** [[source]](https://github.com/bsegovia/cube)
+- **[AssaultCube](https://assault.cubers.net)** - A FREE, multiplayer, first-person shooter game. [[source]](https://github.com/assaultcube/AC) **Engine: [CUBE](http://cubeengine.com)** [[source]](https://github.com/bsegovia/cube) **Language: C++**
 
-- **[Cube 2: Sauerbraten](http://sauerbraten.org)** - A free multiplayer & singleplayer first person shooter. [[source]](https://sourceforge.net/projects/sauerbraten) **Engine: [CUBE](https://www.redeclipse.net)** [[source]](https://github.com/bsegovia/cube)
+- **[Cube 2: Sauerbraten](http://sauerbraten.org)** - A free multiplayer & singleplayer first person shooter. [[source]](https://sourceforge.net/projects/sauerbraten) **Engine: [CUBE](https://www.redeclipse.net)** [[source]](https://github.com/bsegovia/cube) **Language: C++**
 
-- **[Descent 3](https://en.wikipedia.org/wiki/Descent_3)** - A first-person shooter video game/ [[source]](https://github.com/kevinbentley/Descent3)
+- **[Descent 3](https://en.wikipedia.org/wiki/Descent_3)** - A first-person shooter video game/ [[source]](https://github.com/kevinbentley/Descent3) **Language: C++**
 
-- **[Liblast](https://libla.st)** - A Libre Multiplayer FPS Game built with Godot 4 engine and a fully open-source toolchain. [[source]](https://codeberg.org/liblast/liblast) **Engine: [Godot](https://godotengine.org)** [[source]](https://github.com/godotengine/godot)
+- **[Liblast](https://libla.st)** - A Libre Multiplayer FPS Game built with Godot 4 engine and a fully open-source toolchain. [[source]](https://codeberg.org/liblast/liblast) **Engine: [Godot](https://godotengine.org)** [[source]](https://github.com/godotengine/godot) **Language: GDScript**
 
-- **[Red Eclipse](https://www.redeclipse.net)** - An old-school arena shooter for the modern age. [[source]](https://github.com/redeclipse/base) **Engine: [CUBE](https://www.redeclipse.net)** [[source]](https://github.com/bsegovia/cube)
+- **[Red Eclipse](https://www.redeclipse.net)** - An old-school arena shooter for the modern age. [[source]](https://github.com/redeclipse/base) **Engine: [CUBE](https://www.redeclipse.net)** [[source]](https://github.com/bsegovia/cube) **Language: C++**
 
-- **Surreal Engine** - [Unreal Tournament](https://en.wikipedia.org/wiki/Unreal_Tournament) Engine Reimplementation. [[source]](https://github.com/dpjudas/SurrealEngine)
+- **Surreal Engine** - [Unreal Tournament](https://en.wikipedia.org/wiki/Unreal_Tournament) Engine Reimplementation. [[source]](https://github.com/dpjudas/SurrealEngine) **Language: C++**
 
-- **[The Dark Mod](https://www.thedarkmod.com/main)** - First-person stealth video game. [[source]](https://svn.thedarkmod.com/publicsvn/darkmod_src/trunk)
+- **[The Dark Mod](https://www.thedarkmod.com/main)** - First-person stealth video game. [[source]](https://svn.thedarkmod.com/publicsvn/darkmod_src/trunk) **Language: C++**
 
-- **[Xonotic](https://xonotic.org)** - An addictive arena-style first person shooter with crisp movement and a wide array of weapons. [[source]](https://gitlab.com/xonotic/xonotic)
+- **[Xonotic](https://xonotic.org)** - An addictive arena-style first person shooter with crisp movement and a wide array of weapons. [[source]](https://gitlab.com/xonotic/xonotic) **Language: C++**
 
 ### *[Aliens Versus Predator](https://en.wikipedia.org/wiki/Aliens_Versus_Predator_(1999_video_game)) game source ports*
 
-- **AvP Forever** - Project focuses on maintenance of available source code for *Aliens versus Predator (1999)* game. [[source]](https://github.com/dreamer/avp-forever)
+- **AvP Forever** - Project focuses on maintenance of available source code for *Aliens versus Predator (1999)* game. [[source]](https://github.com/dreamer/avp-forever) **Language: C**
 
-- **avpmp** - Fork of the original AvP port for Linux, expanded with multiplayer and other features. [[source]](https://github.com/mbait/avpmp)
+- **avpmp** - Fork of the original AvP port for Linux, expanded with multiplayer and other features. [[source]](https://github.com/mbait/avpmp) **Language: C**
 
-- **NakedAVP** - A port of *Aliens vs Predator Classic (2000)* to modern systems, based on the icculus port for Linux, macOS and Windows using [SDL3](https://libsdl.org/) ([[source]](https://github.com/libsdl-org/SDL)). [[source]](https://github.com/atsb/NakedAVP)
+- **NakedAVP** - A port of *Aliens vs Predator Classic (2000)* to modern systems, based on the icculus port for Linux, macOS and Windows using [SDL3](https://libsdl.org/) ([[source]](https://github.com/libsdl-org/SDL)). [[source]](https://github.com/atsb/NakedAVP) **Language: C**
 
 ### *[Build engine](https://en.wikipedia.org/wiki/Build_(game_engine)) [[source]](https://advsys.net/ken/buildsrc) based games*
 
-- **[Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D)** - By [3D Realms Entertainment, Inc](https://en.wikipedia.org/wiki/3D_Realms). [[source]](https://github.com/videogamepreservation/dukenukem3d)
+- **[Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D)** - By [3D Realms Entertainment, Inc](https://en.wikipedia.org/wiki/3D_Realms). [[source]](https://github.com/videogamepreservation/dukenukem3d) **Language: C**
 
-- **Shadow Warrior** - Official source release for [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)). [[source]](https://github.com/Azarien/shadow-warrior)
+- **Shadow Warrior** - Official source release for [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)). [[source]](https://github.com/Azarien/shadow-warrior) **Language: C**
 
 #### *Source Ports and Re-Implementations*
 
-- **BuildGDX** - [[source]](https://github.com/vogonsorg/BuildGDX)
+- **BuildGDX** - [[source]](https://github.com/vogonsorg/BuildGDX) **Language: Java**
 
-- **[EDuke32](https://voidpoint.io/terminx/eduke32)** - The official EDuke32 Git repository: home to the source code to EDuke32, [Ion Fury](https://en.wikipedia.org/wiki/Ion_Fury), VoidSW, Mapster32, and related projects based on the Build Engine.
+- **[EDuke32](https://voidpoint.io/terminx/eduke32)** - The official EDuke32 Git repository: home to the source code to EDuke32, [Ion Fury](https://en.wikipedia.org/wiki/Ion_Fury), VoidSW, Mapster32, and related projects based on the Build Engine. **Language: C**
 
-- **[JFDuke3D](https://www.jonof.id.au/jfduke3d)** - Port of the [3D Realms](https://en.wikipedia.org/wiki/3D_Realms) game [Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D) [[source]](https://github.com/jonof/jfduke3d)
+- **[JFDuke3D](https://www.jonof.id.au/jfduke3d)** - Port of the [3D Realms](https://en.wikipedia.org/wiki/3D_Realms) game [Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D) [[source]](https://github.com/jonof/jfduke3d) **Language: C**
 
-- **[JFShadowWarrior](https://www.jonof.id.au/jfsw)** - Port of the [3D Realms](https://en.wikipedia.org/wiki/3D_Realms) game [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)).
+- **[JFShadowWarrior](https://www.jonof.id.au/jfsw)** - Port of the [3D Realms](https://en.wikipedia.org/wiki/3D_Realms) game [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)). **Language: C**
 
-- **[NBlood](https://github.com/NBlood/NBlood)** - Reverse-engineered ports of Build games using EDuke32 engine technology and development principles (NBlood/Rednukem/PCExhume d) [[source]](https://github.com/NBlood/NBlood)
+- **[NBlood](https://github.com/NBlood/NBlood)** - Reverse-engineered ports of Build games using EDuke32 engine technology and development principles (NBlood/Rednukem/PCExhume d) [[source]](https://github.com/NBlood/NBlood) **Language: C**
 
-- **NuBuildGDX** -  A fork of BuildGDX aiming for stability, bug fixing and performance. [[source]](https://github.com/atsb/NuBuildGDX)
+- **NuBuildGDX** -  A fork of BuildGDX aiming for stability, bug fixing and performance. [[source]](https://github.com/atsb/NuBuildGDX) **Language: Java**
 
-- **[Raze](https://github.com/ZDoom/Raze)** - Build engine port backed by GZDoom tech. Currently supports [Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D), [Blood](https://en.wikipedia.org/wiki/Blood_(video_game)), [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)), [Redneck Rampage](https://en.wikipedia.org/wiki/Redneck_Rampage) and [Powerslave](https://en.wikipedia.org/wiki/PowerSlave)/Exhumed.
+- **[Raze](https://github.com/ZDoom/Raze)** - Build engine port backed by GZDoom tech. Currently supports [Duke Nukem 3D](https://en.wikipedia.org/wiki/Duke_Nukem_3D), [Blood](https://en.wikipedia.org/wiki/Blood_(video_game)), [Shadow Warrior](https://en.wikipedia.org/wiki/Shadow_Warrior_(1997_video_game)), [Redneck Rampage](https://en.wikipedia.org/wiki/Redneck_Rampage) and [Powerslave](https://en.wikipedia.org/wiki/PowerSlave)/Exhumed. **Language: C++**
 
 ### *[id Software](https://en.wikipedia.org/wiki/Id_Software) Games*
 
-- **[Doom](https://en.wikipedia.org/wiki/Doom_(1993_video_game))** - [[source]](https://github.com/id-Software/DOOM)
+- **[Doom](https://en.wikipedia.org/wiki/Doom_(1993_video_game))** - [[source]](https://github.com/id-Software/DOOM) **Language: C**
 
-- **DOOM64-RE** - Complete reverse engineering of [Doom 64](https://en.wikipedia.org/wiki/Doom_64). [[source]](https://github.com/Erick194/DOOM64-RE)
+- **DOOM64-RE** - Complete reverse engineering of [Doom 64](https://en.wikipedia.org/wiki/Doom_64). [[source]](https://github.com/Erick194/DOOM64-RE) **Language: C**
 
-- **[Doom 3](https://en.wikipedia.org/wiki/Doom_3) BFG Edition** - [[source]](https://github.com/id-Software/DOOM-3-BFG)
+- **[Doom 3](https://en.wikipedia.org/wiki/Doom_3) BFG Edition** - [[source]](https://github.com/id-Software/DOOM-3-BFG) **Language: C++**
 
-- **[Quake](https://en.wikipedia.org/wiki/Quake_(video_game))** - [[source]](https://github.com/id-Software/Quake)
+- **[Quake](https://en.wikipedia.org/wiki/Quake_(video_game))** - [[source]](https://github.com/id-Software/Quake) **Language: C**
 
-- **[Quake II](https://en.wikipedia.org/wiki/Quake_II)** - [[source]](https://github.com/id-Software/Quake-2)
+- **[Quake II](https://en.wikipedia.org/wiki/Quake_II)** - [[source]](https://github.com/id-Software/Quake-2) **Language: C**
 
-- **[Quake III Arena](https://en.wikipedia.org/wiki/Quake_III_Arena)** - [[source]](https://github.com/id-Software/Quake-III-Arena)
+- **[Quake III Arena](https://en.wikipedia.org/wiki/Quake_III_Arena)** - [[source]](https://github.com/id-Software/Quake-III-Arena) **Language: C**
 
-- **[Wolfenstein 3D](https://en.wikipedia.org/wiki/Wolfenstein_3D)** - [[source]](https://github.com/id-Software/wolf3d)
+- **[Wolfenstein 3D](https://en.wikipedia.org/wiki/Wolfenstein_3D)** - [[source]](https://github.com/id-Software/wolf3d) **Language: C**
 
 #### *Source Ports and Re-Implementations*
 
 - **[Catacomb 3-D](https://en.wikipedia.org/wiki/Catacomb_3-D)**
 
-  - **CatacombGL** -  A source port of Catacomb 3D and the Catacomb Adventure series. [[source]](https://github.com/ArnoAnsems/CatacombGL)
+  - **CatacombGL** -  A source port of Catacomb 3D and the Catacomb Adventure series. [[source]](https://github.com/ArnoAnsems/CatacombGL) **Language: C**
 
 - **[Doom](https://en.wikipedia.org/wiki/Doom_(1993_video_game))**
 
-  - **[Chocolate Doom](https://www.chocolate-doom.org)** - A Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s. [[source]](https://github.com/chocolate-doom/chocolate-doom)
+  - **[Chocolate Doom](https://www.chocolate-doom.org)** - A Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s. [[source]](https://github.com/chocolate-doom/chocolate-doom) **Language: C/C++**
 
-  - **[ZDoom](https://zdoom.org)** - A feature centric port for all Doom engine games. [[source]](https://github.com/UZDoom/UZDoom)
+  - **[ZDoom](https://zdoom.org)** - A feature centric port for all Doom engine games. [[source]](https://github.com/UZDoom/UZDoom) **Language: C/C++**
 
 - **[Quake](https://en.wikipedia.org/wiki/Quake_(video_game))**
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ This is a list of different open-source video games and commercial video games o
 
 ## Action games
 
-- **[Hypersomnia](https://hypersomnia.io)** - Competitive top-down shooter with extreme dynamics and pixely nostalgia. Comes with a built-in map Editor. [[source]](https://github.com/TeamHypersomnia/Hypersomnia)
+- **[Hypersomnia](https://hypersomnia.io)** - Competitive top-down shooter with extreme dynamics and pixely nostalgia. Comes with a built-in map Editor. [[source]](https://github.com/TeamHypersomnia/Hypersomnia) **Language: C++**
 
 ## Adventure games
 
-- **[Dead Ascend](https://blackgrain.dk/games/deadascend)** - A zombie adventure, escape room, with twists. [[source]](https://github.com/larpon/DeadAscend)
+- **[Dead Ascend](https://blackgrain.dk/games/deadascend)** - A zombie adventure, escape room, with twists. [[source]](https://github.com/larpon/DeadAscend) **Lannguage: C++ (Qt/QML)**
 
-- **[Endless Sky](https://endless-sky.github.io)** - Space exploration, trading, and combat game. [[source]](https://github.com/endless-sky/endless-sky)
+- **[Endless Sky](https://endless-sky.github.io)** - Space exploration, trading, and combat game. [[source]](https://github.com/endless-sky/endless-sky) **Language: C++**
 
-- **[Pioneer](https://pioneerspacesim.net)** - A space adventure game set in our galaxy at the turn of the 33rd century. [[source]](https://github.com/pioneerspacesim/pioneer)
+- **[Pioneer](https://pioneerspacesim.net)** - A space adventure game set in our galaxy at the turn of the 33rd century. [[source]](https://github.com/pioneerspacesim/pioneer) **Language: C++**
 
-- **[ScummVM](https://www.scummvm.org)** - A program which allows you to run certain classic graphical adventure and role-playing games. [[source]](https://github.com/scummvm/scummvm)
+- **[ScummVM](https://www.scummvm.org)** - A program which allows you to run certain classic graphical adventure and role-playing games. [[source]](https://github.com/scummvm/scummvm) **Language: C++**
 
-- **[The Legend of Zelda: Twilight Princess](https://zsrtp.link)** - A reverse engineering project to decompile *[Twilight Princess](https://en.wikipedia.org/wiki/The_Legend_of_Zelda:_Twilight_Princess)* into human-readable and modifiable source code. [[source]](https://github.com/zeldaret/tp)
+- **[The Legend of Zelda: Twilight Princess](https://zsrtp.link)** - A reverse engineering project to decompile *[Twilight Princess](https://en.wikipedia.org/wiki/The_Legend_of_Zelda:_Twilight_Princess)* into human-readable and modifiable source code. [[source]](https://github.com/zeldaret/tp) **Language: C**
 
-- **Zelda 3** - A reverse engineered clone of *[The Legend of Zelda: A Link to the Past](https://en.wikipedia.org/wiki/The_Legend_of_Zelda:_A_Link_to_the_Past)*. [[source]](https://github.com/snesrev/zelda3)
+- **Zelda 3** - A reverse engineered clone of *[The Legend of Zelda: A Link to the Past](https://en.wikipedia.org/wiki/The_Legend_of_Zelda:_A_Link_to_the_Past)*. [[source]](https://github.com/snesrev/zelda3) **Language: C**
 
 ## Business and Tycoon games
 

--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ This is a list of different open-source video games and commercial video games o
 
 - **[Quake](https://en.wikipedia.org/wiki/Quake_(video_game))**
 
-  - **Chocolate Quake** - A purist Quake source port that restores the original look and feel of v1.09 and earlier. [[source]](https://github.com/Henrique194/chocolate-quake)
+  - **Chocolate Quake** - A purist Quake source port that restores the original look and feel of v1.09 and earlier. [[source]](https://github.com/Henrique194/chocolate-quake) **Language: C**
 
   - **[FTEQW](https://www.fteqw.org)** - Powerful engine for playing and modding idTech based games. [[source]](https://github.com/fte-team/fteqw)
 
 - **[Wolfenstein 3D](https://en.wikipedia.org/wiki/Wolfenstein_3D)**
 
-  - **ECWolf** - A port of the Wolfenstein 3D engine based of Wolf4SDL. [[source]](https://bitbucket.org/ecwolf/ecwolf)
+  - **ECWolf** - A port of the Wolfenstein 3D engine based of Wolf4SDL. [[source]](https://bitbucket.org/ecwolf/ecwolf) **Language: C++**
 
-  - **Wolf4SDL** - An open-source port of id Software's classic first-person shooter Wolfenstein 3D to the cross-platform multimedia library SDL. [[source]](https://github.com/lazd/wolf4sdl)
+  - **Wolf4SDL** - An open-source port of id Software's classic first-person shooter Wolfenstein 3D to the cross-platform multimedia library SDL. [[source]](https://github.com/lazd/wolf4sdl) **Language: C++**
 
 ## Platformers
 
@@ -176,41 +176,41 @@ Commander Keen (1-6, Dreams) and [Cosmo's Cosmic](https://en.wikipedia.org/wiki/
 which allows you to play the original episodes and
 some of the mods made for them. [[source]](https://gitlab.com/Dringgstein/Commander-Genius)
 
-  - **[Commander Keen in Keen Dreams](https://en.wikipedia.org/wiki/Commander_Keen_in_Keen_Dreams)** - A side-scrolling platform video game developed by id Software. [[source]](https://github.com/keendreams/keen)
+  - **[Commander Keen in Keen Dreams](https://en.wikipedia.org/wiki/Commander_Keen_in_Keen_Dreams)** - A side-scrolling platform video game developed by id Software. [[source]](https://github.com/keendreams/keen) **Language: C++**
 
-  - **Omnispeak** - An open-source re-implementation of [Commander Keen in Goodbye Galaxy](https://en.wikipedia.org/wiki/Commander_Keen_in_Goodbye,_Galaxy). [[source]](https://github.com/sulix/omnispeak)
+  - **Omnispeak** - An open-source re-implementation of [Commander Keen in Goodbye Galaxy](https://en.wikipedia.org/wiki/Commander_Keen_in_Goodbye,_Galaxy). [[source]](https://github.com/sulix/omnispeak) **Language: C**
 
 - **[DDraceNetwork](https://ddnet.tw)** - Cooperative 2D online platformer. [[source]](https://github.com/ddnet/ddnet)
 
 - **[Fish Folk](https://fishfolk.org) Games**
 
-  - **[Jumpy](https://fishfolk.org/games/jumpy)** - A tactical 2D shooter. [[source]](https://github.com/fishfolk/jumpy) **Engine: [Bevy](https://bevy.org/)** [[source]](https://github.com/bevyengine/bevy)
+  - **[Jumpy](https://fishfolk.org/games/jumpy)** - A tactical 2D shooter. [[source]](https://github.com/fishfolk/jumpy) **Engine: [Bevy](https://bevy.org/)** [[source]](https://github.com/bevyengine/bevy) **Language: Rust**
 
-  - **[Punchy](https://github.com/fishfolk/punchy)** - A 2.5D side-scroller beatemup, made in Bevy. **Engine: [Bevy](https://bevy.org/)** [[source]](https://github.com/bevyengine/bevy)
+  - **[Punchy](https://github.com/fishfolk/punchy)** - A 2.5D side-scroller beatemup, made in Bevy. **Engine: [Bevy](https://bevy.org/)** [[source]](https://github.com/bevyengine/bevy) **Language: Rust**
 
-- **[Frogatto & Friends](https://frogatto.com)** - An action-adventure platformer game, starring a certain quixotic frog. [[source]](https://github.com/frogatto/frogatto) **Engine: Anura** [[source]](https://github.com/anura-engine/anura)
+- **[Frogatto & Friends](https://frogatto.com)** - An action-adventure platformer game, starring a certain quixotic frog. [[source]](https://github.com/frogatto/frogatto) **Engine: Anura** [[source]](https://github.com/anura-engine/anura) **Language: C++**
 
 - **[OpenGOAL](https://opengoal.dev)** - This project is to port [Jak & Daxter Series](https://en.wikipedia.org/wiki/Jak_and_Daxter) to PC. [[source]](https://github.com/water111/jak-project)
 
-- **Rigel Engine** - This project is a re-implementation of the game [Duke Nukem II](https://en.wikipedia.org/wiki/Duke_Nukem_II), originally released by Apogee Software in 1993 for MS-DOS. [[source]](https://github.com/lethal-guitar/RigelEngine)
+- **Rigel Engine** - This project is a re-implementation of the game [Duke Nukem II](https://en.wikipedia.org/wiki/Duke_Nukem_II), originally released by Apogee Software in 1993 for MS-DOS. [[source]](https://github.com/lethal-guitar/RigelEngine) **Language: C++**
 
 - **[Sonic Robo Blast 2](https://www.srb2.org)** - A 3D open-source Sonic the Hedgehog fangame built on Doom. [[source]](https://git.do.srb2.org/STJr/SRB2)
 
 - **Super Mario 64** - A full decompilation of [Super Mario 64](https://en.wikipedia.org/wiki/Super_Mario_64). [[source]](https://github.com/n64decomp/sm64)
 
-- **[VVVVVV](https://thelettervsixtim.es/)** - [[source]](https://github.com/TerryCavanagh/VVVVVV)
+- **[VVVVVV](https://thelettervsixtim.es/)** - [[source]](https://github.com/TerryCavanagh/VVVVVV) **Language: C++**
 
 ## Puzzle games
 
 - **[BlockOut II](http://www.blockout.net/blockout2)** - A free adaptation of the original BlockOut® DOS game edited by California Dreams in 1989. [[source]](https://sourceforge.net/projects/blockout/files/blockout/BlockOut%202.5)
 
-- **Portal64** - A demake (remake for an older platform) of [Portal](https://en.wikipedia.org/wiki/Portal_(video_game)) for the Nintendo 64. [[source]](https://github.com/mwpenny/portal64-still-alive)
+- **Portal64** - A demake (remake for an older platform) of [Portal](https://en.wikipedia.org/wiki/Portal_(video_game)) for the Nintendo 64. [[source]](https://github.com/mwpenny/portal64-still-alive) **Language: C**
 
-- **[Whatajong](https://whatajong.com)** - [[source]](https://github.com/masylum/whatajong)
+- **[Whatajong](https://whatajong.com)** - [[source]](https://github.com/masylum/whatajong) **Language: TypeScript**
 
 ## Racing games
 
-- **[Dust Racing 2D](https://github.com/juzzlin/DustRacing2D)** - A traditional top-down car racing game including a level editor. [[source]](https://github.com/cflavio/yorg)
+- **[Dust Racing 2D](https://github.com/juzzlin/DustRacing2D)** - A traditional top-down car racing game including a level editor. [[source]](https://github.com/cflavio/yorg) **Language: C++**
 
 - **[ManiaDrive](http://maniadrive.raydium.org)** - A free clone of [TrackMania](https://en.wikipedia.org/wiki/TrackMania), the great game from [Nadéo](https://en.wikipedia.org/wiki/Nadeo) studio. [[source]](http://maniadrive.raydium.org/index.php?downloads=yes) **Engine: [Raydium](https://raydium.org)** [[source]](https://raydium.org/data.php)
 
@@ -220,17 +220,17 @@ some of the mods made for them. [[source]](https://gitlab.com/Dringgstein/Comman
 
 - **[Speed Dreams](https://www.speed-dreams.net)** - A free and open source motorsport simulator. [[source]](https://forge.a-lec.org/xavi/speed-dreams-code)
 
-- **[Stunt Rally](https://stuntrally.tuxfamily.org)** - 3D racing game with Sci-Fi elements and own Track Editor. [[source]](https://github.com/stuntrally/stuntrally3)
+- **[Stunt Rally](https://stuntrally.tuxfamily.org)** - 3D racing game with Sci-Fi elements and own Track Editor. [[source]](https://github.com/stuntrally/stuntrally3) **Language: C++**
 
-- **[SuperTuxKart](https://supertuxkart.net)** - A free kart racing game. It focuses on fun and not on realistic kart physics. [[source]](https://github.com/supertuxkart/stk-code)
+- **[SuperTuxKart](https://supertuxkart.net)** - A free kart racing game. It focuses on fun and not on realistic kart physics. [[source]](https://github.com/supertuxkart/stk-code) **Language: C++**
 
 - **[TORCS - The Open Racing Car Simulator](https://torcs.sourceforge.net)** - A highly portable multi platform car racing simulation. It is used as ordinary car racing game, as AI racing game and as research platform. [[source]](https://sourceforge.net/projects/torcs)
 
 - **[Trigger Rally](https://trigger-rally.sourceforge.io)** - A fast-paced single-player racing game for Linux and Windows. [[source]](https://sourceforge.net/projects/trigger-rally)
 
-- **[VDrift](https://vdrift.net)** - A cross-platform, open source driving simulation made with drift racing in mind. [[source]](https://github.com/VDrift/vdrift)
+- **[VDrift](https://vdrift.net)** - A cross-platform, open source driving simulation made with drift racing in mind. [[source]](https://github.com/VDrift/vdrift) **Language: C++**
 
-- **[Yorg](https://ya2.itch.io/yorg)** - Yorg (Yorg's an Open Racing Game) is a free open source racing game developed by Ya2 using Panda3D for Windows, OSX and Linux. [[source]](https://github.com/cflavio/yorg) **Engine: [Panda3D](https://www.panda3d.org)** [[source]](https://github.com/panda3d/panda3d)
+- **[Yorg](https://ya2.itch.io/yorg)** - Yorg (Yorg's an Open Racing Game) is a free open source racing game developed by Ya2 using Panda3D for Windows, OSX and Linux. [[source]](https://github.com/cflavio/yorg) **Engine: [Panda3D](https://www.panda3d.org)** [[source]](https://github.com/panda3d/panda3d) **Language: Python**
 
 - **[wipEout](https://phoboslab.org/log/2023/08/rewriting-wipeout)** - This is a re-implementation of the 1995 PSX game [Wipeout](https://en.wikipedia.org/wiki/Wipeout_(video_game)). [[source]](https://github.com/phoboslab/wipeout-rewrite)
 
@@ -240,86 +240,86 @@ some of the mods made for them. [[source]](https://gitlab.com/Dringgstein/Comman
 
 - **[BAR](https://www.beyondallreason.info)** - Beyond All Reason. [[source]](https://github.com/beyond-all-reason/Beyond-All-Reason) **Engine: [Spring](https://springrts.com)** [[source]](https://github.com/spring/spring)
 
-- **[Dune II The Maker](https://dune2themaker.fundynamic.com)** - A Dune 2 remake. [[source]](https://github.com/stefanhendriks/Dune-II---The-Maker)
+- **[Dune II The Maker](https://dune2themaker.fundynamic.com)** - A Dune 2 remake. [[source]](https://github.com/stefanhendriks/Dune-II---The-Maker) **Language: C++**
 
-- **Freeserf.net** - Аn authentic remake of the game [The Settlers I](https://en.wikipedia.org/wiki/The_Settlers) by [BlueByte](https://en.wikipedia.org/wiki/Ubisoft_Blue_Byte). [[source]](https://github.com/Pyrdacor/freeserf.net)
+- **Freeserf.net** - Аn authentic remake of the game [The Settlers I](https://en.wikipedia.org/wiki/The_Settlers) by [BlueByte](https://en.wikipedia.org/wiki/Ubisoft_Blue_Byte). [[source]](https://github.com/Pyrdacor/freeserf.net) **Language: C#**
 
-- **[Keeper FX](https://keeperfx.net)** - An open-source remake and fan expansion of [Dungeon Keeper](https://en.wikipedia.org/wiki/Dungeon_Keeper). [[source]](https://github.com/dkfans/keeperfx)
+- **[Keeper FX](https://keeperfx.net)** - An open-source remake and fan expansion of [Dungeon Keeper](https://en.wikipedia.org/wiki/Dungeon_Keeper). [[source]](https://github.com/dkfans/keeperfx) **Language: C++**
 
-- **[Mindustry](https://mindustrygame.github.io)** - A sandbox tower-defense game. [[source]](https://github.com/Anuken/Mindustry)
+- **[Mindustry](https://mindustrygame.github.io)** - A sandbox tower-defense game. [[source]](https://github.com/Anuken/Mindustry) **Language: Java**
 
-- **[OpenAge](https://openage.sft.mx)** - A free (as in freedom) cross-platform RTS game engine that provides the mechanics of [Age of Empires](https://en.wikipedia.org/wiki/Age_of_Empires). [[source]](https://github.com/SFTtech/openage)
+- **[OpenAge](https://openage.sft.mx)** - A free (as in freedom) cross-platform RTS game engine that provides the mechanics of [Age of Empires](https://en.wikipedia.org/wiki/Age_of_Empires). [[source]](https://github.com/SFTtech/openage) **Language: C++**
 
-- **[OpenHV](https://www.openhv.net)** - An Open Source Pixelart Science-Fiction Real-Time-Strategy game. [[source]](https://github.com/OpenHV/OpenHV)
+- **[OpenHV](https://www.openhv.net)** - An Open Source Pixelart Science-Fiction Real-Time-Strategy game. [[source]](https://github.com/OpenHV/OpenHV) **Language: C#**
 
-- **[OpenRA](https://www.openra.net)** - [Command & Conquer](https://en.wikipedia.org/wiki/Command_%26_Conquer), [Dune 2000](https://en.wikipedia.org/wiki/Dune_2000) and [Red Alert](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Red_Alert) rebuild for the Modern Era. [[source]](https://github.com/OpenRA/OpenRA)
+- **[OpenRA](https://www.openra.net)** - [Command & Conquer](https://en.wikipedia.org/wiki/Command_%26_Conquer), [Dune 2000](https://en.wikipedia.org/wiki/Dune_2000) and [Red Alert](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Red_Alert) rebuild for the Modern Era. [[source]](https://github.com/OpenRA/OpenRA) **Language: C#**
 
-- **Permafrost Engine** - An OpenGL 3.3 Real Time Strategy game engine written in C. [[source]](https://github.com/eduard-permyakov/permafrost-engine)
+- **Permafrost Engine** - An OpenGL 3.3 Real Time Strategy game engine written in C. [[source]](https://github.com/eduard-permyakov/permafrost-engine) **Language: C**
 
-- **Standard Of Iron** - A modern real-time strategy (RTS) game engine built with C++20, Qt 6, and OpenGL 3.3 Core. [[source]](https://github.com/djeada/Standard-of-Iron)
+- **Standard Of Iron** - A modern real-time strategy (RTS) game engine built with C++20, Qt 6, and OpenGL 3.3 Core. [[source]](https://github.com/djeada/Standard-of-Iron) **Language: C++**
 
-- **[Warzone 2100](https://wz2100.net)** -  A free, open source, 3D real-time strategy game with a story-driven single-player campaign, online multi-player, offline skirmish, and more. [[source]](https://github.com/Warzone2100/warzone2100)
+- **[Warzone 2100](https://wz2100.net)** -  A free, open source, 3D real-time strategy game with a story-driven single-player campaign, online multi-player, offline skirmish, and more. [[source]](https://github.com/Warzone2100/warzone2100) **Language: C++**
 
-- **[Widelands](https://www.widelands.org)** - A free, open source real-time strategy game. [[source]](https://github.com/widelands/widelands)
+- **[Widelands](https://www.widelands.org)** - A free, open source real-time strategy game. [[source]](https://github.com/widelands/widelands) **Language: C++**
 
 - **[Zero-K](https://zero-k.info/)** - RTS game with physical projectiles, smart units
-and a powerful UI. [[source]](https://github.com/ZeroK-RTS/Zero-K) **Engine: [Spring](https://springrts.com)** [[source]](https://github.com/spring/spring)
+and a powerful UI. [[source]](https://github.com/ZeroK-RTS/Zero-K) **Engine: [Spring](https://springrts.com)** [[source]](https://github.com/spring/spring) **Language: C#**
 
 ### *[Blizzard Entertainment](https://en.wikipedia.org/wiki/Blizzard_Entertainment) Games Re-Implementations*
 
-- **OpenBW** - Free and open-source Best Wargame. [[source]](https://github.com/OpenBW/openbw) **[Brood War API](https://bwapi.github.io)** [[source]](https://github.com/OpenBW/bwapi)
+- **OpenBW** - Free and open-source Best Wargame. [[source]](https://github.com/OpenBW/openbw) **[Brood War API](https://bwapi.github.io)** [[source]](https://github.com/OpenBW/bwapi) **Language: C++**
 
-- **[Strategus](https://stratagus.com)** Engine Games [[source]](https://github.com/Wargus/stratagus)
+- **[Strategus](https://stratagus.com)** Engine Games [[source]](https://github.com/Wargus/stratagus) **Language: C++**
 
-  - **[War1gus](https://stratagus.com/war1gus.html)** - A re-implementation of [Warcraft: Orcs & Humans](https://en.wikipedia.org/wiki/Warcraft:_Orcs_%26_Humans) that that can be played on modern platforms. [[source]](https://github.com/Wargus/war1gus)
+  - **[War1gus](https://stratagus.com/war1gus.html)** - A re-implementation of [Warcraft: Orcs & Humans](https://en.wikipedia.org/wiki/Warcraft:_Orcs_%26_Humans) that that can be played on modern platforms. [[source]](https://github.com/Wargus/war1gus) **Language: C++**
 
-  - **[Wargus](https://stratagus.com)** - Importer and scripts for [Warcraft II: Tides of Darkness](https://en.wikipedia.org/wiki/Warcraft_II:_Tides_of_Darkness), the expansion [Beyond the Dark Portal](https://en.wikipedia.org/wiki/Warcraft_II:_Beyond_the_Dark_Portal), and Aleonas Tales. [[source]](https://github.com/Wargus/wargus)
+  - **[Wargus](https://stratagus.com)** - Importer and scripts for [Warcraft II: Tides of Darkness](https://en.wikipedia.org/wiki/Warcraft_II:_Tides_of_Darkness), the expansion [Beyond the Dark Portal](https://en.wikipedia.org/wiki/Warcraft_II:_Beyond_the_Dark_Portal), and Aleonas Tales. [[source]](https://github.com/Wargus/wargus) **Language: C++**
 
-  - **[Wyrmsun](https://andrettin.github.io)** - A strategy game which features elements of mythology, history and fiction. [[source]](https://github.com/Andrettin/Wyrmsun)
+  - **[Wyrmsun](https://andrettin.github.io)** - A strategy game which features elements of mythology, history and fiction. [[source]](https://github.com/Andrettin/Wyrmsun) **Language: C++**
 
-  - **[Stargus](https://stratagus.com/stratagus.html)** - Importer and scripts for [Starcraft](https://en.wikipedia.org/wiki/StarCraft). [[source]](https://github.com/Wargus/stargus)
+  - **[Stargus](https://stratagus.com/stratagus.html)** - Importer and scripts for [Starcraft](https://en.wikipedia.org/wiki/StarCraft). [[source]](https://github.com/Wargus/stargus) **Language: C++**
 
-- **Warsmash Mod Engine** - An emulation engine to improve Warcraft III modding. [[source]](https://github.com/Retera/WarsmashModEngine) **Engine: [LibGDX](https://libgdx.com)** [[source]](https://github.com/libgdx/libgdx)
+- **Warsmash Mod Engine** - An emulation engine to improve Warcraft III modding. [[source]](https://github.com/Retera/WarsmashModEngine) **Engine: [LibGDX](https://libgdx.com)** [[source]](https://github.com/libgdx/libgdx) **Language: Java**
 
 ### *[Westwood Studios](https://en.wikipedia.org/wiki/Westwood_Studios) and [EA](https://en.wikipedia.org/wiki/Electronic_Arts) Games from [Command & Conquer](https://en.wikipedia.org/wiki/Command_%26_Conquer) Series*
 
-- **Command & Conquer Remastered Collection** - TiberianDawn.dll, RedAlert.dll and the Map Editor for the [Command & Conquer Remastered Collection](https://en.wikipedia.org/wiki/Command_%26_Conquer_Remastered_Collection). [[source]](https://github.com/electronicarts/CnC_Remastered_Collection)
+- **Command & Conquer Remastered Collection** - TiberianDawn.dll, RedAlert.dll and the Map Editor for the [Command & Conquer Remastered Collection](https://en.wikipedia.org/wiki/Command_%26_Conquer_Remastered_Collection). [[source]](https://github.com/electronicarts/CnC_Remastered_Collection) **Language: C++**
 
-- **Generals** - [Command & Conquer Generals](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Generals), and its expansion pack [Zero Hour](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Generals_%E2%80%93_Zero_Hour). [[source]](https://github.com/electronicarts/CnC_Generals_Zero_Hour)
+- **Generals** - [Command & Conquer Generals](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Generals), and its expansion pack [Zero Hour](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Generals_%E2%80%93_Zero_Hour). [[source]](https://github.com/electronicarts/CnC_Generals_Zero_Hour) **Language: C++**
 
-- **[Red Alert](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Red_Alert)** - [[source]](https://github.com/electronicarts/CnC_Red_Alert)
+- **[Red Alert](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Red_Alert)** - [[source]](https://github.com/electronicarts/CnC_Red_Alert) **Language: C++**
 
-- **[Tiberian Dawn](https://en.wikipedia.org/wiki/Command_%26_Conquer_(1995_video_game))** - [[source]](https://github.com/electronicarts/CnC_Tiberian_Dawn)
+- **[Tiberian Dawn](https://en.wikipedia.org/wiki/Command_%26_Conquer_(1995_video_game))** - [[source]](https://github.com/electronicarts/CnC_Tiberian_Dawn) **Language: C++**
 
 ## Roguelikes
 
-- **[Brogue CE](https://sites.google.com/site/broguegame/)** - Brogue is a minimalist, turn-based, procedurally-generated roguelike game where you descend a perilous dungeon to retrieve the Amulet of Yendor. [[source]](https://github.com/tmewett/BrogueCE)
+- **[Brogue CE](https://sites.google.com/site/broguegame/)** - Brogue is a minimalist, turn-based, procedurally-generated roguelike game where you descend a perilous dungeon to retrieve the Amulet of Yendor. [[source]](https://github.com/tmewett/BrogueCE) **Language: C**
 
-- **[Cataclysm: Dark Days Ahead](https://cataclysmdda.org)** - A turn-based survival game set in a post-apocalyptic world. [[source]](https://github.com/CleverRaven/Cataclysm-DDA)
+- **[Cataclysm: Dark Days Ahead](https://cataclysmdda.org)** - A turn-based survival game set in a post-apocalyptic world. [[source]](https://github.com/CleverRaven/Cataclysm-DDA) **Language: C++**
 
-- **[Dungeon Crawl Stone Soup](https://crawl.develz.org)** - An open source roguelike adventure through dungeons filled with dangerous monsters in a quest to find the mystifyingly fabulous Orb of Zot. [[source]](https://github.com/crawl/crawl)
+- **[Dungeon Crawl Stone Soup](https://crawl.develz.org)** - An open source roguelike adventure through dungeons filled with dangerous monsters in a quest to find the mystifyingly fabulous Orb of Zot. [[source]](https://github.com/crawl/crawl) **Language: C++**
 
-- **[NetHack](https://nethack.org)** - Single player dungeon exploration game. [[source]](https://github.com/NetHack/NetHack)
+- **[NetHack](https://nethack.org)** - Single player dungeon exploration game. [[source]](https://github.com/NetHack/NetHack) **Language: C**
 
-- **[Meritous](http://asceai.net/meritous)** - An action-adventure dungeon crawl game. [[source]](https://github.com/Patashu/Meritous)
+- **[Meritous](http://asceai.net/meritous)** - An action-adventure dungeon crawl game. [[source]](https://github.com/Patashu/Meritous) **Language: C**
 
-- **OpenNefia** - Moddable engine reimplementation of the Japanese roguelike [Elona](https://en.wikipedia.org/wiki/Elona_(video_game)). [[source]](https://github.com/OpenNefia/OpenNefia)
+- **OpenNefia** - Moddable engine reimplementation of the Japanese roguelike [Elona](https://en.wikipedia.org/wiki/Elona_(video_game)). [[source]](https://github.com/OpenNefia/OpenNefia) **Language: Lua**
 
-- **[Shattered Pixel Dungeon](https://shatteredpixel.com)** - An open-source traditional roguelike dungeon crawler with randomized levels and enemies, and hundreds of items to collect and use. [[source]](https://github.com/00-Evan/shattered-pixel-dungeon)
+- **[Shattered Pixel Dungeon](https://shatteredpixel.com)** - An open-source traditional roguelike dungeon crawler with randomized levels and enemies, and hundreds of items to collect and use. [[source]](https://github.com/00-Evan/shattered-pixel-dungeon) **Language: Java**
 
 ## Role-Playing games
 
-- **[Ambermoon.net](https://pyrdacor.itch.io/ambermoon)** - A full C# rewrite of [Ambermoon](https://en.wikipedia.org/wiki/Ambermoon). [[source]](https://github.com/Pyrdacor/Ambermoon.net)
+- **[Ambermoon.net](https://pyrdacor.itch.io/ambermoon)** - A full C# rewrite of [Ambermoon](https://en.wikipedia.org/wiki/Ambermoon). [[source]](https://github.com/Pyrdacor/Ambermoon.net) **Language: C#**
 
-- **[Daggerfall Unity](https://www.dfworkshop.net)** - An open source recreation of [Daggerfall](https://en.wikipedia.org/wiki/The_Elder_Scrolls_II:_Daggerfall) in the Unity engine. [[source]](https://github.com/Interkarma/daggerfall-unity)
+- **[Daggerfall Unity](https://www.dfworkshop.net)** - An open source recreation of [Daggerfall](https://en.wikipedia.org/wiki/The_Elder_Scrolls_II:_Daggerfall) in the Unity engine. [[source]](https://github.com/Interkarma/daggerfall-unity) **Language: C#**
 
-- **[Exult](https://exult.sourceforge.io)** - A project to recreate [Ultima VII](https://en.wikipedia.org/wiki/Ultima_VII:_The_Black_Gate) for modern operating systems. [[source]](https://github.com/exult/exult)
+- **[Exult](https://exult.sourceforge.io)** - A project to recreate [Ultima VII](https://en.wikipedia.org/wiki/Ultima_VII:_The_Black_Gate) for modern operating systems. [[source]](https://github.com/exult/exult) **Language: C++**
 
-- **Fallout Community Edition** - A fully working re-implementation of [Fallout](https://en.wikipedia.org/wiki/Fallout_(video_game)). [[source]](https://github.com/alexbatalov/fallout1-ce)
+- **Fallout Community Edition** - A fully working re-implementation of [Fallout](https://en.wikipedia.org/wiki/Fallout_(video_game)). [[source]](https://github.com/alexbatalov/fallout1-ce) **Language: C**
 
-- **Fallout 2 Community Edition** - A fully working re-implementation of [Fallout 2](https://en.wikipedia.org/wiki/Fallout_2). [[source]](https://github.com/alexbatalov/fallout2-ce)
+- **Fallout 2 Community Edition** - A fully working re-implementation of [Fallout 2](https://en.wikipedia.org/wiki/Fallout_2). [[source]](https://github.com/alexbatalov/fallout2-ce) **Language: C**
 
-- **[GemRB](https://gemrb.org)** - A portable open-source implementation of Bioware’s [Infinity Engine](https://en.wikipedia.org/wiki/Infinity_Engine) [[source]](https://en.wikipedia.org/wiki/Infinity_Engine)
+- **[GemRB](https://gemrb.org)** - A portable open-source implementation of Bioware’s [Infinity Engine](https://en.wikipedia.org/wiki/Infinity_Engine) [[source]](https://en.wikipedia.org/wiki/Infinity_Engine) **Language: C++**
 
   **Supported games:**
 
@@ -331,111 +331,111 @@ and a powerful UI. [[source]](https://github.com/ZeroK-RTS/Zero-K) **Engine: [Sp
 
   - [Icewind Dale II](https://en.wikipedia.org/wiki/Icewind_Dale_II)
 
-  - [Planescape: Torment](https://en.wikipedia.org/wiki/Planescape:_Torment)
+  - [Planescape: Torment](https://en.wikipedia.org/wiki/Planescape:_Torment) 
 
-- **[Kandria](https://kandria.com)** - An action RPG made in Common Lisp. [[source]](https://codeberg.org/shirakumo/kandria) **Engine: [Trial](https://shirakumo.org/docs/trial/)** [[source]](https://codeberg.org/shirakumo/trial)
+- **[Kandria](https://kandria.com)** - An action RPG made in Common Lisp. [[source]](https://codeberg.org/shirakumo/kandria) **Engine: [Trial](https://shirakumo.org/docs/trial/)** [[source]](https://codeberg.org/shirakumo/trial) **Language: Common Lisp**
 
-- **[Naev](https://naev.org)** - A 2d action/rpg space game that combines elements from the action, rpg and simulation genres. [[source]](https://codeberg.org/naev/naev)
+- **[Naev](https://naev.org)** - A 2d action/rpg space game that combines elements from the action, rpg and simulation genres. [[source]](https://codeberg.org/naev/naev) **Language: C**
 
-- **[Oolite](https://www.oolite.space/)** - An open-world space opera. [[source]](https://github.com/OoliteProject/oolite)
+- **[Oolite](https://www.oolite.space/)** - An open-world space opera. [[source]](https://github.com/OoliteProject/oolite) **Language: Objective-C**
 
-- **OpenEnroth** - [Might and Magic VI-VIII](https://en.wikipedia.org/wiki/Might_and_Magic) engine remake using original data & code. [[source]](https://github.com/OpenEnroth/OpenEnroth)
+- **OpenEnroth** - [Might and Magic VI-VIII](https://en.wikipedia.org/wiki/Might_and_Magic) engine remake using original data & code. [[source]](https://github.com/OpenEnroth/OpenEnroth) **Language: C++**
 
-- **[OpenMW](https://openmw.org)** - A free, open source, and modern engine which re-implements and extends the 2002 Gamebryo engine for the open-world role-playing game [The Elder Scrolls III: Morrowind](https://en.wikipedia.org/wiki/The_Elder_Scrolls_III:_Morrowind). [[source]](https://github.com/OpenMW/openmw)
+- **[OpenMW](https://openmw.org)** - A free, open source, and modern engine which re-implements and extends the 2002 Gamebryo engine for the open-world role-playing game [The Elder Scrolls III: Morrowind](https://en.wikipedia.org/wiki/The_Elder_Scrolls_III:_Morrowind). [[source]](https://github.com/OpenMW/openmw) **Language: C++**
 
-- **OpenNox** - An open-source community collaboration project extending the Nox engine. [[source]](https://github.com/noxworld-dev/opennox)
+- **OpenNox** - An open-source community collaboration project extending the Nox engine. [[source]](https://github.com/noxworld-dev/opennox) **Language: Go**
 
-- **reone** - A free and open source game engine, capable of running [Star Wars: Knights of the Old Republic](https://en.wikipedia.org/wiki/Star_Wars:_Knights_of_the_Old_Republic) and its sequel, [The Sith Lords](https://en.wikipedia.org/wiki/Star_Wars_Knights_of_the_Old_Republic_II:_The_Sith_Lords). [[source]](https://github.com/seedhartha/reone)
+- **reone** - A free and open source game engine, capable of running [Star Wars: Knights of the Old Republic](https://en.wikipedia.org/wiki/Star_Wars:_Knights_of_the_Old_Republic) and its sequel, [The Sith Lords](https://en.wikipedia.org/wiki/Star_Wars_Knights_of_the_Old_Republic_II:_The_Sith_Lords). [[source]](https://github.com/seedhartha/reone) **Language: C++**
 
-- **[Severed Chains](https://legendofdragoon.org/projects/severed-chains)** - [The Legend of Dragoon](https://en.wikipedia.org/wiki/The_Legend_of_Dragoon) decompiled, reverse engineered, and ported to PC/Mac/Linux/Steam Deck. [[source]](https://github.com/Legend-of-Dragoon-Modding/Severed-Chains)
+- **[Severed Chains](https://legendofdragoon.org/projects/severed-chains)** - [The Legend of Dragoon](https://en.wikipedia.org/wiki/The_Legend_of_Dragoon) decompiled, reverse engineered, and ported to PC/Mac/Linux/Steam Deck. [[source]](https://github.com/Legend-of-Dragoon-Modding/Severed-Chains) **Language: Java**
 
-- **[Space Station 14](https://spacestation14.io/)** – Open-source remake of [Space Station 13](https://en.wikipedia.org/wiki/Space_Station_13). [[source]](https://github.com/space-wizards/space-station-14)
+- **[Space Station 14](https://spacestation14.io/)** – Open-source remake of [Space Station 13](https://en.wikipedia.org/wiki/Space_Station_13). [[source]](https://github.com/space-wizards/space-station-14) **Language: C#**
 
-- **[Ultima VII: Revisited](https://www.u7revisited.com)** - A replacement engine for [Ultima VII](https://en.wikipedia.org/wiki/Ultima_VII:_The_Black_Gate) that presents the game in 3D and fixes various issues with the game. [[source]](https://github.com/ViridianGames/U7Revisited)
+- **[Ultima VII: Revisited](https://www.u7revisited.com)** - A replacement engine for [Ultima VII](https://en.wikipedia.org/wiki/Ultima_VII:_The_Black_Gate) that presents the game in 3D and fixes various issues with the game. [[source]](https://github.com/ViridianGames/U7Revisited) **Language: C#**
 
-- **[Veloren](https://www.veloren.net/)** - multiplayer voxel RPG written in Rust. [[source]](https://github.com/veloren/veloren)
+- **[Veloren](https://www.veloren.net/)** - multiplayer voxel RPG written in Rust. [[source]](https://github.com/veloren/veloren) **Language: Rust**
 
 ### *[Diablo](https://en.wikipedia.org/wiki/Diablo_(series)) Re-Implementations*
 
-- **Abyss Engine** - Clean-room reimplementation of [Diablo 2](https://en.wikipedia.org/wiki/Diablo_II), written in C. [[source]](https://github.com/AbyssEngine/AbyssEngine)
+- **Abyss Engine** - Clean-room reimplementation of [Diablo 2](https://en.wikipedia.org/wiki/Diablo_II), written in C. [[source]](https://github.com/AbyssEngine/AbyssEngine) **Language: C**
 
-- **[DevilutionX](https://devilutionx.com/)** - A port of [Diablo](https://en.wikipedia.org/wiki/Diablo_(video_game)) and [Hellfire](https://en.wikipedia.org/wiki/Diablo:_Hellfire) that strives to make it simple to run the game while providing engine improvements, bugfixes, and some optional quality of life features. [[source]](https://github.com/diasurgical/devilutionX)
+- **[DevilutionX](https://devilutionx.com/)** - A port of [Diablo](https://en.wikipedia.org/wiki/Diablo_(video_game)) and [Hellfire](https://en.wikipedia.org/wiki/Diablo:_Hellfire) that strives to make it simple to run the game while providing engine improvements, bugfixes, and some optional quality of life features. [[source]](https://github.com/diasurgical/devilutionX) **Language: C++**
 
-- **[Freeablo](https://freeablo.org)** - A work-in-progress free and open-source replacement for the [Diablo I](https://en.wikipedia.org/wiki/Diablo_(video_game)) engine. [[source]](https://github.com/wheybags/freeablo)
+- **[Freeablo](https://freeablo.org)** - A work-in-progress free and open-source replacement for the [Diablo I](https://en.wikipedia.org/wiki/Diablo_(video_game)) engine. [[source]](https://github.com/wheybags/freeablo) **Language: C++**
 
-- **Open Diablo II** - An open source re-implementation of [Diablo 2](https://en.wikipedia.org/wiki/Diablo_II). [[source]](https://github.com/OpenDiablo2/OpenDiablo2)
+- **Open Diablo II** - An open source re-implementation of [Diablo 2](https://en.wikipedia.org/wiki/Diablo_II). [[source]](https://github.com/OpenDiablo2/OpenDiablo2) **Language: Go**
 
 ### *Massively Multiplayer Online Role-Playing Games*
 
-- **OpenKO** - An open source version of the old school [Knight Online](https://en.wikipedia.org/wiki/Knight_Online) MMORPG. [[source]](https://github.com/Open-KO/KnightOnline)
+- **OpenKO** - An open source version of the old school [Knight Online](https://en.wikipedia.org/wiki/Knight_Online) MMORPG. [[source]](https://github.com/Open-KO/KnightOnline) **Language: C++**
 
-- **OpenKore** - A custom client and intelligent automated assistant for [Ragnarok Online](https://en.wikipedia.org/wiki/Ragnarok_Online). [[source]](https://github.com/OpenKore/openkore)
+- **OpenKore** - A custom client and intelligent automated assistant for [Ragnarok Online](https://en.wikipedia.org/wiki/Ragnarok_Online). [[source]](https://github.com/OpenKore/openkore) **Language: Perl**
 
 ## Sandbox games
 
-- **Minosoft** - An open source minecraft client, written from scratch in Kotlin (and java). [[source]](https://github.com/bixilon/minosoft) [[source]](https://gitlab.bixilon.de/bixilon/minosoft)
+- **Minosoft** - An open source minecraft client, written from scratch in Kotlin (and java). [[source]](https://github.com/bixilon/minosoft) [[source]](https://gitlab.bixilon.de/bixilon/minosoft) **Language: Kotlin** 
 
 ## Shoot 'em up games
 
-- **[SDL Sopwith](https://fragglet.github.io/sdl-sopwith)** - A port of the classic biplane shoot ‘em-up “Sopwith” to run on modern computers and operating systems. [[source]](https://github.com/fragglet/sdl-sopwith)
+- **[SDL Sopwith](https://fragglet.github.io/sdl-sopwith)** - A port of the classic biplane shoot ‘em-up “Sopwith” to run on modern computers and operating systems. [[source]](https://github.com/fragglet/sdl-sopwith) **Language: C**
 
-- **[Taisei Project](https://taisei-project.org)** - A free and open-source fangame of the [Tōhō series](https://en.wikipedia.org/wiki/Touhou_Project), written in C using SDL3 and OpenGL. [[source]](https://github.com/taisei-project/taisei)
+- **[Taisei Project](https://taisei-project.org)** - A free and open-source fangame of the [Tōhō series](https://en.wikipedia.org/wiki/Touhou_Project), written in C using SDL3 and OpenGL. [[source]](https://github.com/taisei-project/taisei) **Language: C**
 
 ## Sport games
 
-- **[Open Golf](https://mgerdes.github.io/minigolf.html)** - A cross-platform minigolf game written in C. [[source]](https://github.com/mgerdes/Open-Golf)
+- **[Open Golf](https://mgerdes.github.io/minigolf.html)** - A cross-platform minigolf game written in C. [[source]](https://github.com/mgerdes/Open-Golf) **Language: C**
 
-- **[Pooltool](https://pooltool.readthedocs.io)** - A sandbox billiards game that emphasizes realistic physics. [[source]](https://github.com/ekiefl/pooltool)
+- **[Pooltool](https://pooltool.readthedocs.io)** - A sandbox billiards game that emphasizes realistic physics. [[source]](https://github.com/ekiefl/pooltool) **Language: Python**
 
 ## Third-Person games
 
-- **[Command & Conquer Renegade](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Renegade)** - [[source]](https://github.com/electronicarts/CnC_Renegade)
+- **[Command & Conquer Renegade](https://en.wikipedia.org/wiki/Command_%26_Conquer:_Renegade)** - [[source]](https://github.com/electronicarts/CnC_Renegade) **Language: C++**
 
-- **CroftEngine** - An open-source [Tomb Raider 1](https://en.wikipedia.org/wiki/Tomb_Raider_(1996_video_game)) engine remake. [[source]](https://github.com/stohrendorf/CroftEngine)
+- **CroftEngine** - An open-source [Tomb Raider 1](https://en.wikipedia.org/wiki/Tomb_Raider_(1996_video_game)) engine remake. [[source]](https://github.com/stohrendorf/CroftEngine) **Language: C++**
 
-- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[source]](https://github.com/WolfireGames/lugaru)
+- **[Lugaru: The Rabbit's Foot](http://www.wolfire.com/lugaru)** - Cross-platform, open-source 3D action game. [[source]](https://github.com/WolfireGames/lugaru) **Language: C++**
 
-- **[OpenLara](http://xproger.info/projects/OpenLara)** - Classic Tomb Raider open-source engine. [[source]](https://github.com/XProger/OpenLara)
+- **[OpenLara](http://xproger.info/projects/OpenLara)** - Classic Tomb Raider open-source engine. [[source]](https://github.com/XProger/OpenLara) **Language: C++**
 
-- **[OpenRW](https://openrw.org)** - A [Grand Theft Auto III](https://en.wikipedia.org/wiki/Grand_Theft_Auto_III) re-implementation. [[source]](https://github.com/rwengine/openrw)
+- **[OpenRW](https://openrw.org)** - A [Grand Theft Auto III](https://en.wikipedia.org/wiki/Grand_Theft_Auto_III) re-implementation. [[source]](https://github.com/rwengine/openrw) **Language: C++**
 
-- **[Overgrowth](https://overgrowth.wolfire.com)** - The sequel to Lugaru. [[source]](https://github.com/WolfireGames/overgrowth)
+- **[Overgrowth](https://overgrowth.wolfire.com)** - The sequel to Lugaru. [[source]](https://github.com/WolfireGames/overgrowth) **Language: C++**
 
-- **RE3** - The fully reversed source code for [GTA III](https://en.wikipedia.org/wiki/Grand_Theft_Auto_III) and [GTA VC](https://en.wikipedia.org/wiki/Grand_Theft_Auto:_Vice_City). [[source]](https://github.com/VideogameSources/gta3-decomp-alt)
+- **RE3** - The fully reversed source code for [GTA III](https://en.wikipedia.org/wiki/Grand_Theft_Auto_III) and [GTA VC](https://en.wikipedia.org/wiki/Grand_Theft_Auto:_Vice_City). [[source]](https://github.com/VideogameSources/gta3-decomp-alt) **Language: C++**
 
-- **[Tomb Engine](https://tombengine.com)** - An open-source engine for custom [Tomb Raider](https://en.wikipedia.org/wiki/Tomb_Raider) adventures. Core Design era (1 - 5). [[source]](https://github.com/TombEngine/TombEngine)
+- **[Tomb Engine](https://tombengine.com)** - An open-source engine for custom [Tomb Raider](https://en.wikipedia.org/wiki/Tomb_Raider) adventures. Core Design era (1 - 5). [[source]](https://github.com/TombEngine/TombEngine) **Language: C++**
 
 ## Tower Defence games
 
-- **[Server Survival](https://pshenok.github.io/server-survival)** - Tower defense game that teaches cloud architecture. Build infrastructure, survive traffic, learn scaling. [[source]](https://github.com/pshenok/server-survival)
+- **[Server Survival](https://pshenok.github.io/server-survival)** - Tower defense game that teaches cloud architecture. Build infrastructure, survive traffic, learn scaling. [[source]](https://github.com/pshenok/server-survival) **Language: TypeScript**
 
 ## Turn-Based strategies
 
-- [Ancient Beast](https://ancientbeast.com) - A turn based strategy indie game project played online against other people. [[source]](https://github.com/FreezingMoon/AncientBeast)
+- [Ancient Beast](https://ancientbeast.com) - A turn based strategy indie game project played online against other people. [[source]](https://github.com/FreezingMoon/AncientBeast) **Language: TypeScript**
 
-- **[Athena Crisis](https://athenacrisis.com)** - A modern-retro turn-based tactical strategy game. [[source]](https://github.com/nkzw-tech/athena-crisis)
+- **[Athena Crisis](https://athenacrisis.com)** - A modern-retro turn-based tactical strategy game. [[source]](https://github.com/nkzw-tech/athena-crisis) **Language: TypeScript**
 
-- **[C-evo](http://c-evo.org/)** - A freeware empire-building game for Windows. [[source]](http://c-evo.org/files/files.php)
+- **[C-evo](http://c-evo.org/)** - A freeware empire-building game for Windows. [[source]](http://c-evo.org/files/files.php) **Language: Delphi**
 
-- **[fheroes2](https://ihhub.github.io/fheroes2)** - A recreation of [Heroes of Might and Magic II](https://en.wikipedia.org/wiki/Heroes_of_Might_and_Magic_II) game engine. [[source]](https://github.com/ihhub/fheroes2)
+- **[fheroes2](https://ihhub.github.io/fheroes2)** - A recreation of [Heroes of Might and Magic II](https://en.wikipedia.org/wiki/Heroes_of_Might_and_Magic_II) game engine. [[source]](https://github.com/ihhub/fheroes2) **Language: C++**
 
-- **[FreeCol](https://www.freecol.org/)** - A turn-based strategy game based on the old game[Colonization](https://en.wikipedia.org/wiki/Sid_Meier%27s_Colonization), and similar to [Civilization](https://en.wikipedia.org/wiki/Civilization_(video_game)). [[source]](https://github.com/FreeCol/freecol)
+- **[FreeCol](https://www.freecol.org/)** - A turn-based strategy game based on the old game[Colonization](https://en.wikipedia.org/wiki/Sid_Meier%27s_Colonization), and similar to [Civilization](https://en.wikipedia.org/wiki/Civilization_(video_game)). [[source]](https://github.com/FreeCol/freecol) **Language: Java**
 
-- **[Freeciv](http://www.freeciv.org/)** - A Free and Open Source empire-building strategy game. [[source]](https://github.com/freeciv/freeciv)
+- **[Freeciv](http://www.freeciv.org/)** - A Free and Open Source empire-building strategy game. [[source]](https://github.com/freeciv/freeciv) **Language: C**
 
-- **[FreeOrion](https://www.freeorion.org/index.php/Main_Page)** - A free, open source, turn-based space empire and galactic conquest (4X) computer game. [[source]](https://github.com/freeorion/freeorion)
+- **[FreeOrion](https://www.freeorion.org/index.php/Main_Page)** - A free, open source, turn-based space empire and galactic conquest (4X) computer game. [[source]](https://github.com/freeorion/freeorion) **Language: C++**
 
-- **[Hnefatafl](https://hnefatafl.org/)** - The game of Copenhagen Hnefatafl. Sort of like chess. [[source]](https://github.com/dcampbell24/hnefatafl)
+- **[Hnefatafl](https://hnefatafl.org/)** - The game of Copenhagen Hnefatafl. Sort of like chess. [[source]](https://github.com/dcampbell24/hnefatafl) **Language: Rust**
 
-- **[OpenPanzer](https://www.linuxconsulting.ro/openpanzer)** - Javascript/HTML5 rewrite of [Panzer General II](https://en.wikipedia.org/wiki/Panzer_General_II) game. [[source]](https://github.com/nicupavel/openpanzer)
+- **[OpenPanzer](https://www.linuxconsulting.ro/openpanzer)** - Javascript/HTML5 rewrite of [Panzer General II](https://en.wikipedia.org/wiki/Panzer_General_II) game. [[source]](https://github.com/nicupavel/openpanzer) **Language: JavaScript**
 
-- **[OpenXcom](https://openxcom.org/)** - An open-source clone of the popular [UFO: Enemy Unknown](https://en.wikipedia.org/wiki/UFO:_Enemy_Unknown) and [X-COM: Terror From the Deep](https://en.wikipedia.org/wiki/X-COM:_Terror_from_the_Deep) video games by [MicroPros](https://en.wikipedia.org/wiki/MicroProse). [[source]](https://github.com/OpenXcom/OpenXcom)
+- **[OpenXcom](https://openxcom.org/)** - An open-source clone of the popular [UFO: Enemy Unknown](https://en.wikipedia.org/wiki/UFO:_Enemy_Unknown) and [X-COM: Terror From the Deep](https://en.wikipedia.org/wiki/X-COM:_Terror_from_the_Deep) video games by [MicroPros](https://en.wikipedia.org/wiki/MicroProse). [[source]](https://github.com/OpenXcom/OpenXcom) **Language: C++**
 
-- **[The Battle for Wesnoth](https://www.wesnoth.org/)** - A turn-based strategy game with a high fantasy theme. [[source]](https://github.com/wesnoth/wesnoth)
+- **[The Battle for Wesnoth](https://www.wesnoth.org/)** - A turn-based strategy game with a high fantasy theme. [[source]](https://github.com/wesnoth/wesnoth) **Language: C++**
 
-- **[Unciv](https://yairm210.itch.io/unciv)** - Open-source Android/Desktop remake of [Civilization V](https://en.wikipedia.org/wiki/Civilization_V). [[source]](https://github.com/yairm210/Unciv)
+- **[Unciv](https://yairm210.itch.io/unciv)** - Open-source Android/Desktop remake of [Civilization V](https://en.wikipedia.org/wiki/Civilization_V). [[source]](https://github.com/yairm210/Unciv) **Language: Kotlin**
 
-- **[VCMI Project](https://vcmi.eu)** - Open-source engine for [Heroes of Might and Magic III](https://en.wikipedia.org/wiki/Heroes_of_Might_and_Magic_III). [[source]](https://github.com/vcmi/vcmi)
+- **[VCMI Project](https://vcmi.eu)** - Open-source engine for [Heroes of Might and Magic III](https://en.wikipedia.org/wiki/Heroes_of_Might_and_Magic_III). [[source]](https://github.com/vcmi/vcmi) **Language: C++**
 
 ## Other lists
 


### PR DESCRIPTION
## Summary

Closes #71.

Adds a `**Language: X**` tag to every game entry in `README.md`, inserted after the `[[source]]` link tag.

## Why

Developers browsing this list often want to find games written in a specific language — to study idiomatic patterns, pick contribution targets, or evaluate a language for a new project. Without this metadata, every entry requires a click-through to the source repo.

## Format used

**Before:**
```bash
[Game Name] - Description. [[source]]
[Game Name] - Description. Engine: [X] [[source]]
```
**After:**
```bash
[Game Name] - Description. [[source]] Languages: []
[Game Name] - Description. Engine: [X] [[source]] Language: []
```

## Testing
Since this is a documentation-only change, traditional unit tests don't apply. 

## Verification method

Each language was determined by:
1. Checking the GitHub repo's top-level language badge.
2. Cross-referencing with the repo's own README where the language is stated explicitly.
3. For projects with multiple languages, the language of the game engine itself is used.

## Checklist
- [x] No existing links or engine tags broken
- [x] Format consistent across all sections